### PR TITLE
Fixes tests not running on macOS (2)

### DIFF
--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -122,7 +122,7 @@ actual_file="${result_dir}/rebar3_app%mylib%list-functions%my_complete"
 # - Select the lines that start with "%     complete_"
 # - Remove the "%     " part from the beginning
 # - Print the rest to ${expected_file}
-sed -n '/^%     complete_/{s/^%     //;p}' \
+sed -n '/^%     complete_/{s/^%     //;p;}' \
     "${fixture_dir}/rebar3_app/mylib/src/my_complete.erl" \
     > "${expected_file}"
 


### PR DESCRIPTION
BSD sed needs the "p" command to terminate with a semicolon before closing "}".

Appears as an example here: https://riptutorial.com/sed/topic/9436/bsd-macos-sed-vs--gnu-sed-vs--the-posix-sed-specification

>Inside function lists (multiple function calls enclosed in {...}), be sure to also terminate the last function, before the closing }, with ;.